### PR TITLE
Add missing Javadoc

### DIFF
--- a/src/main/java/com/saucelabs/rdc/Rdc.java
+++ b/src/main/java/com/saucelabs/rdc/Rdc.java
@@ -8,20 +8,43 @@ import java.util.concurrent.TimeUnit;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 import static java.util.concurrent.TimeUnit.MINUTES;
 
+/**
+ * Configuration of the {@link RdcAppiumSuite} runner.
+ */
 @Retention(RUNTIME)
 @Target(ElementType.TYPE)
 public @interface Rdc {
+	/**
+	 * The API key that is used for accessing Sauce Labs' Real Device Cloud.
+	 * Please don't put it under version control.
+	 */
 	String apiKey() default "";
 
+	/**
+	 * The ID of the test suite.
+	 */
 	long suiteId();
 
 	String apiUrl() default "https://app.testobject.com/api";
 
+	/**
+	 * The version of the application that is used for testing.
+	 */
 	long appId() default -1;
 
+	/**
+	 * Timeout for a single test. Per default the timeout is in minutes. You
+	 * can change the time unit by setting {@link #timeoutUnit()}.
+	 */
 	int timeout() default 60;
 
+	/**
+	 * The time unit for the specified {@link #timeout()}.
+	 */
 	TimeUnit timeoutUnit() default MINUTES;
 
+	/**
+	 * The test is executed against a local device when set to {@code true}.
+	 */
 	boolean testLocally() default false;
 }

--- a/src/main/java/com/saucelabs/rdc/RdcAppiumSuite.java
+++ b/src/main/java/com/saucelabs/rdc/RdcAppiumSuite.java
@@ -50,9 +50,10 @@ import static java.util.Objects.requireNonNull;
  *    {@literal @Before}
  *     public void setup() {
  *         DesiredCapabilities capabilities = new DesiredCapabilities();
- *         capabilities.setCapability({@link RdcCapabilities#API_KEY}, "Your project API key");
+ *         capabilities.setCapability({@link RdcCapabilities#API_KEY}, {@link RdcAppiumSuiteWatcher#getApiKey() watcher.getApiKey()});
+ *         capabilities.setCapability({@link RdcCapabilities#TEST_REPORT_ID}, {@link RdcAppiumSuiteWatcher#getTestReportId() watcher.getTestReportId()});
  *
- *         driver = new AndroidDriver({@link RdcEndpoints#EU_ENDPOINT}, capabilities);
+ *         driver = new AndroidDriver({@link RdcAppiumSuiteWatcher#getAppiumEndpointUrl() watcher.getAppiumEndpointUrl()}, capabilities);
  *         watcher.setRemoteWebDriver(driver);
  *     }
  *
@@ -70,12 +71,12 @@ import static java.util.Objects.requireNonNull;
  *
  * <h2>Additional Settings</h2>
  *
- * The two setting {@code suiteId} and {@code apiKey} are mandatory but there
+ * The two settings {@code suiteId} and {@code apiKey} are mandatory but there
  * are also some optional settings that you can use.
  *
  * <h3>App ID</h3>
- * <p>The id of your app changes every time you upload a new release. Either
- * you update the id of the app that is used by the suite manually at the Sauce
+ * <p>The ID of your app changes every time you upload a new release. Either
+ * you update the ID of the app that is used by the suite manually at the Sauce
  * Labs website or you can use the {@code RdcAppiumSuite} runner. It updates
  * the app ID when you set the element {@link Rdc#appId() appId} of the
  * {@code @Rdc} annotation or if you set an environment variable

--- a/src/main/java/com/saucelabs/rdc/RdcCapabilities.java
+++ b/src/main/java/com/saucelabs/rdc/RdcCapabilities.java
@@ -1,5 +1,11 @@
 package com.saucelabs.rdc;
 
+/**
+ * A collection of capabilities that are supported by Sauce Labs. More
+ * information is available at
+ * <a href="https://wiki.saucelabs.com/display/DOCS/Appium+Capabilities+for+Real+Device+Testing#AppiumCapabilitiesforRealDeviceTesting-WebDriverAgentTimeoutforiOSDevices">Appium
+ * Capabilities for Real Device Testing.</a>
+ */
 public class RdcCapabilities {
 	public static final String API_KEY = "testobject_api_key";
 	public static final String DEVICE = "testobject_device";

--- a/src/main/java/com/saucelabs/rdc/RdcEndpoints.java
+++ b/src/main/java/com/saucelabs/rdc/RdcEndpoints.java
@@ -3,6 +3,15 @@ package com.saucelabs.rdc;
 import java.net.MalformedURLException;
 import java.net.URL;
 
+/**
+ * The Appium remote addresses of Sauce Labs' data centers. You can use them
+ * for creating your remote {@code AppiumDriver}.
+ * <pre>
+ *     driver = new AppiumDriver({@link RdcEndpoints#US_ENDPOINT}, capabilities);
+ * </pre>
+ *
+ * @since 1.0.0
+ */
 public class RdcEndpoints {
 
 	public static final URL US_ENDPOINT = getUrl("https://us1.appium.testobject.com/wd/hub");

--- a/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
+++ b/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
@@ -14,7 +14,7 @@ import static com.saucelabs.rdc.helper.RdcEnvironmentVariables.getApiEndpoint;
 /**
  * An {@code RdcTestResultWatcher} updates the result of a test at Sauce Labs.
  * <p>Sauce Labs stores data about each test that you are executing on its Real
- * Device Cloud, e.g. request logs and screen shots. By default Sauce Labs does
+ * Device Cloud, e.g. request logs and screenshots. By default Sauce Labs does
  * not store the result of an Appium test. This is because the test result is
  * determined by the client that executes the test and therefore Sauce Labs
  * does not know about it.


### PR DESCRIPTION
Make it easier for users to get information about the provided classes.

Best way to read the Javadoc:

1. Run `mvn javadoc:javadoc`
2. Open `target/site/apidoc/index.html`
3. Navigate to the Javadoc of the classes in the package `com.saucelabs.rdc`