### PR TITLE
Delete setters

### DIFF
--- a/src/main/java/com/saucelabs/rdc/RdcAppiumSuiteWatcher.java
+++ b/src/main/java/com/saucelabs/rdc/RdcAppiumSuiteWatcher.java
@@ -131,23 +131,11 @@ public class RdcAppiumSuiteWatcher implements TestRule {
 	}
 
 	public void configure(String apiKey, long suiteId, SuiteReport suiteReport, boolean isLocalTest, URL appiumUrl, URL apiUrl) {
-		reporter = new SuiteReporter(suiteId, suiteReport);
-		setApiKey(apiKey);
-		setIsLocalTest(isLocalTest);
-		setAppiumUrl(appiumUrl);
-		setApiUrl(apiUrl);
-	}
-
-	public void setAppiumUrl(URL appiumUrl) {
-		this.appiumUrl = appiumUrl;
-	}
-
-	public void setApiUrl(URL apiUrl) {
+		this.apiKey = apiKey;
 		this.apiUrl = apiUrl;
-	}
-
-	public void setIsLocalTest(boolean isLocalTest) {
+		this.appiumUrl = appiumUrl;
 		this.isLocalTest = isLocalTest;
+		this.reporter = new SuiteReporter(suiteId, suiteReport);
 	}
 
 	/**
@@ -179,10 +167,6 @@ public class RdcAppiumSuiteWatcher implements TestRule {
 	 */
 	public String getApiKey() {
 		return apiKey;
-	}
-
-	public void setApiKey(String apiKey) {
-		this.apiKey = apiKey;
 	}
 
 	/**


### PR DESCRIPTION
There is no use case where a user of the library has to use one of these
setters. The fields are only set the RdcAppiumSuite runner by the method
"configure".
Removing the setters also helps the user of the library because they
don't have to think about these methods anymore.