### PR TITLE
Print stack trace when test report is not updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ RDC Appium Support for JUnit 4 is available on
 <dependency>
   <groupId>com.saucelabs</groupId>
   <artifactId>rdc-appium-junit4</artifactId>
-  <version>2.0.0</version>
+  <version>2.1.0</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.saucelabs</groupId>
     <artifactId>rdc-appium-junit4</artifactId>
-    <version>2.0.0</version>
+    <version>2.1.0</version>
     <packaging>jar</packaging>
 
     <name>RDC Appium JUnit 4</name>

--- a/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
+++ b/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
@@ -6,6 +6,8 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
+import java.io.PrintStream;
+import java.io.StringWriter;
 import java.net.MalformedURLException;
 import java.net.URL;
 
@@ -90,9 +92,8 @@ public class RdcTestResultWatcher implements TestRule {
 			try {
 				updateTestReport(passed);
 			} catch (Exception e) {
-				System.err.println(
-					"Failed to update test report. Caused by "
-						+ e.getLocalizedMessage());
+				System.err.println("Failed to update test report. Caused by:");
+				e.printStackTrace(System.err);
 			}
 		}
 	}

--- a/src/test/java/com/saucelabs/rdc/RdcTestResultWatcherTest.java
+++ b/src/test/java/com/saucelabs/rdc/RdcTestResultWatcherTest.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.saucelabs.rdc.RdcCapabilities.API_KEY;
 import static java.util.UUID.randomUUID;
+import static org.apache.commons.lang3.ArrayUtils.subarray;
 import static org.junit.Assert.*;
 import static org.junit.Assume.assumeFalse;
 import static org.junit.Assume.assumeTrue;
@@ -180,9 +181,15 @@ public class RdcTestResultWatcherTest {
 
 		runTest();
 
-		assertTrue(
-			systemErr.getLogWithNormalizedLineSeparator()
-				.startsWith("Failed to update test report."));
+		String[] errorLog = systemErr.getLogWithNormalizedLineSeparator().split("\n");
+		assertArrayEquals(
+			new String[] {
+				"Failed to update test report. Caused by:",
+				"javax.ws.rs.ProcessingException: java.net.ConnectException: Connection refused (Connection refused)",
+				"\tat org.glassfish.jersey.client.internal.HttpUrlConnector.apply(HttpUrlConnector.java:284)",
+				"\tat org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:278)"
+			},
+			subarray(errorLog, 0, 4));
 	}
 
 	@Test


### PR DESCRIPTION
This helps people to find out why the rule failed to update the test report.