### PR TITLE
Report test result even if AppiumDriver is quit 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ RDC Appium Support for JUnit 4 is available on
 <dependency>
   <groupId>com.saucelabs</groupId>
   <artifactId>rdc-appium-junit4</artifactId>
-  <version>2.1.0</version>
+  <version>2.1.1</version>
   <scope>test</scope>
 </dependency>
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.saucelabs</groupId>
     <artifactId>rdc-appium-junit4</artifactId>
-    <version>2.1.1-SNAPSHOT</version>
+    <version>2.1.1</version>
     <packaging>jar</packaging>
 
     <name>RDC Appium JUnit 4</name>

--- a/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
+++ b/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
@@ -6,7 +6,6 @@ import org.junit.runners.model.Statement;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 import static com.saucelabs.rdc.RdcCapabilities.API_KEY;
-import static java.util.Objects.requireNonNull;
 
 /**
  * An {@code RdcTestResultWatcher} updates the result of a test at Sauce Labs.
@@ -94,7 +93,6 @@ public class RdcTestResultWatcher implements TestRule {
 	}
 
 	private void updateTestReport(boolean passed) {
-		requireNonNull(webDriver, "The WebDriver instance is not set.");
 		new SauceLabsApi(apiToken())
 			.updateTestReportStatus(webDriver.getSessionId(), passed);
 	}

--- a/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
+++ b/src/main/java/com/saucelabs/rdc/RdcTestResultWatcher.java
@@ -4,6 +4,7 @@ import org.junit.rules.TestRule;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 import org.openqa.selenium.remote.RemoteWebDriver;
+import org.openqa.selenium.remote.SessionId;
 
 import static com.saucelabs.rdc.RdcCapabilities.API_KEY;
 
@@ -52,15 +53,19 @@ public class RdcTestResultWatcher implements TestRule {
 	private static final boolean PASSED = true;
 
 	private RemoteWebDriver webDriver;
+	private SessionId sessionId;
 
 	/**
 	 * Set the WebDriver. {@code RdcTestResultWatcher} needs to read the API key
-	 * and the session from the {@code AppiumDriver}.
+	 * and the session id from the {@code AppiumDriver}.
 	 * @param webDriver the WebDriver that is used for the test.
 	 * @since 1.0.0
 	 */
 	public void setRemoteWebDriver(RemoteWebDriver webDriver) {
 		this.webDriver = webDriver;
+		// We store the session id immediately because it is null after
+		// webDriver.quit() is called.
+		this.sessionId = webDriver.getSessionId();
 	}
 
 	@Override
@@ -94,7 +99,7 @@ public class RdcTestResultWatcher implements TestRule {
 
 	private void updateTestReport(boolean passed) {
 		new SauceLabsApi(apiToken())
-			.updateTestReportStatus(webDriver.getSessionId(), passed);
+			.updateTestReportStatus(sessionId, passed);
 	}
 
 	private String apiToken() {

--- a/src/test/java/com/saucelabs/rdc/RdcTestResultWatcherTest.java
+++ b/src/test/java/com/saucelabs/rdc/RdcTestResultWatcherTest.java
@@ -95,12 +95,13 @@ public class RdcTestResultWatcherTest {
 
 		TestClass.setWebDriver = true;
 		serverSendsResponse(204);
-		webDriverHasArbitrarySessionId();
+		SessionId sessionId = randomSessionId();
+		webDriverHasSessionId(sessionId);
 		wireMockServerIsApiServer();
 
 		runTest();
 
-		assertEquals("{\"passed\":true}", saucelabsServer.bodyOfLastRequest());
+		assertReported(sessionId, "{\"passed\":true}");
 	}
 
 	@Test
@@ -109,41 +110,13 @@ public class RdcTestResultWatcherTest {
 
 		TestClass.setWebDriver = true;
 		serverSendsResponse(204);
-		webDriverHasArbitrarySessionId();
-		wireMockServerIsApiServer();
-
-		runTest();
-
-		assertEquals("{\"passed\":false}", saucelabsServer.bodyOfLastRequest());
-	}
-
-	@Test
-	public void isReportedToSessionsTestEndpoint() {
-		TestClass.setWebDriver = true;
-		serverSendsResponse(204);
 		SessionId sessionId = randomSessionId();
 		webDriverHasSessionId(sessionId);
 		wireMockServerIsApiServer();
 
 		runTest();
 
-		saucelabsServer.verify(
-			putRequestedFor(
-				urlEqualTo("/rest/v2/appium/session/" + sessionId + "/test")));
-	}
-
-	@Test
-	public void isReportedAsJsonDocument() {
-		TestClass.setWebDriver = true;
-		serverSendsResponse(204);
-		webDriverHasArbitrarySessionId();
-		wireMockServerIsApiServer();
-
-		runTest();
-
-		saucelabsServer.verify(
-			putRequestedFor(anyUrl())
-				.withHeader("Accept", equalTo("application/json")));
+		assertReported(sessionId, "{\"passed\":false}");
 	}
 
 	@Test
@@ -306,6 +279,13 @@ public class RdcTestResultWatcherTest {
 					"An unexpected exception was thrown.", exception);
 			}
 		}
+	}
+
+	private void assertReported(SessionId sessionId, String message) {
+		saucelabsServer.verify(
+			putRequestedFor(urlEqualTo("/rest/v2/appium/session/" + sessionId + "/test"))
+				.withHeader("Accept", equalTo("application/json"))
+				.withRequestBody(equalTo(message)));
 	}
 
 	public static class TestClass {


### PR DESCRIPTION
It is a common pattern that AppiumDriver.quit() is called in an `@After` method. This should not prevent us from reporting the test result.